### PR TITLE
Improve query safety with prepared statements

### DIFF
--- a/admin-client-change-password.php
+++ b/admin-client-change-password.php
@@ -1,15 +1,19 @@
 <?php session_start();
 include "includes/config.php";
 
-if($_SESSION['admin']=='' or $_SESSION['admin']!="yes" or $_GET['cid']=="") 
- {
-    print "<META http-equiv='refresh' content='0;URL=admin-login.php'>";	
+if($_SESSION['admin']=='' or $_SESSION['admin']!="yes" or !isset($_GET['cid']))
+{
+    print "<META http-equiv='refresh' content='0;URL=admin-login.php'>";
     exit;
- }
+}
 
-$qry = "select * from client where c_id_key='".$_GET['cid']."'";
-$rs= $con->recordselect($qry);
-$row=mysqli_fetch_array($rs); 
+$cid = filter_input(INPUT_GET, 'cid', FILTER_SANITIZE_NUMBER_INT);
+$stmt = mysqli_prepare($con->linki, "select * from client where c_id_key=?");
+mysqli_stmt_bind_param($stmt, 'i', $cid);
+mysqli_stmt_execute($stmt);
+$rs = mysqli_stmt_get_result($stmt);
+$row = mysqli_fetch_array($rs);
+mysqli_stmt_close($stmt);
 
 $level = $row['clevel'];
 $cstatus = '';

--- a/admin-rep-change-password.php
+++ b/admin-rep-change-password.php
@@ -1,15 +1,19 @@
 <?php session_start();
 include "includes/config.php";
 
-if($_SESSION['admin']=='' or $_SESSION['admin']!="yes" or $_GET['rid']=="") 
- {
-    print "<META http-equiv='refresh' content='0;URL=admin-login.php'>";	
+if($_SESSION['admin']=='' or $_SESSION['admin']!="yes" or !isset($_GET['rid']))
+{
+    print "<META http-equiv='refresh' content='0;URL=admin-login.php'>";
     exit;
- }
+}
 
-$qry = "select * from model where r_id_key='".$_GET['rid']."'";
-$rs= $con->recordselect($qry);
-$row=mysqli_fetch_array($rs); 
+$rid = filter_input(INPUT_GET, 'rid', FILTER_SANITIZE_NUMBER_INT);
+$stmt = mysqli_prepare($con->linki, "select * from model where r_id_key=?");
+mysqli_stmt_bind_param($stmt, 'i', $rid);
+mysqli_stmt_execute($stmt);
+$rs = mysqli_stmt_get_result($stmt);
+$row = mysqli_fetch_array($rs);
+mysqli_stmt_close($stmt);
 
 ?> 
 

--- a/client-change-password.php
+++ b/client-change-password.php
@@ -7,9 +7,12 @@ if($_SESSION['user_id']=='' or $_SESSION['user_type_r']!="client")
     exit;
  }
 
-$qry = "select * from client where c_id_key='".$_SESSION['user_id']."'";
-$rs= $con->recordselect($qry);
-$row=mysqli_fetch_array($rs); 
+$stmt = mysqli_prepare($con->linki, "select * from client where c_id_key=?");
+mysqli_stmt_bind_param($stmt, 'i', $_SESSION['user_id']);
+mysqli_stmt_execute($stmt);
+$rs = mysqli_stmt_get_result($stmt);
+$row = mysqli_fetch_array($rs);
+mysqli_stmt_close($stmt);
 ?> 
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/rep-change-password.php
+++ b/rep-change-password.php
@@ -7,9 +7,12 @@ if($_SESSION['user_id']=='' or $_SESSION['user_type_r']!="rep")
     exit;
  }
 
-$qry = "select * from model where r_id_key='".$_SESSION['user_id']."'";
-$rs= $con->recordselect($qry);
-$row=mysqli_fetch_array($rs); 
+$stmt = mysqli_prepare($con->linki, "select * from model where r_id_key=?");
+mysqli_stmt_bind_param($stmt, 'i', $_SESSION['user_id']);
+mysqli_stmt_execute($stmt);
+$rs = mysqli_stmt_get_result($stmt);
+$row = mysqli_fetch_array($rs);
+mysqli_stmt_close($stmt);
 ?> 
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


### PR DESCRIPTION
## Summary
- sanitize all request data
- refactor login and password actions to use prepared statements
- secure password change pages with parameterized queries

## Testing
- `php -l action.php`
- `php -l admin-client-change-password.php`
- `php -l admin-rep-change-password.php`
- `php -l client-change-password.php`
- `php -l rep-change-password.php`


------
https://chatgpt.com/codex/tasks/task_b_6884afc9d470832d96f56604e99e0cb2